### PR TITLE
Bump SnapshotTesting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,42 @@
 {
+  "originHash" : "8defe91a54cadbea922d50ed3c6128b98bb7a3e04d68353e24a7b0f13ab37c05",
   "pins" : [
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "5c3d2141fb0e55da411577012c917962b6b3517e",
-        "version" : "1.8.0"
+        "revision" : "1be8144023c367c5de701a6313ed29a3a10bf59b",
+        "version" : "1.18.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "1103c45ece4f7fe160b8f75b4ea1ee2e5fac1841",
+        "version" : "601.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ import PackageDescription
 let package = Package(
 	name: "Stagehand",
 	platforms: [
-		.iOS(.v12),
+		.iOS(.v13),
 		.macOS(.v11),
 	],
 	products: [

--- a/Stagehand.podspec
+++ b/Stagehand.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author           = 'Square'
   s.source           = { :git => 'https://github.com/CashApp/Stagehand.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
 
   s.swift_version = '6.0'
 

--- a/StagehandTesting.podspec
+++ b/StagehandTesting.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author           = 'Square'
   s.source           = { :git => 'https://github.com/CashApp/Stagehand.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
 
   s.swift_version = '6.0'
 


### PR DESCRIPTION
Gets us using latest swift-syntax. Also bumped our minimum supported iOS version because that's what SnapshotTesting's minimum version is (and you can't submit apps for iOS 12 anymore anyways)