### PR TITLE
Clamp progress to reasonable values in interactive animation instance

### DIFF
--- a/Sources/Stagehand/AnimationInstance/InteractiveAnimationInstance.swift
+++ b/Sources/Stagehand/AnimationInstance/InteractiveAnimationInstance.swift
@@ -47,7 +47,7 @@ public final class InteractiveAnimationInstance {
             return
         }
 
-        driver.updateProgress(to: progress)
+        driver.updateProgress(to: progress.clamped(in: 0...1))
     }
 
     public func pause() {


### PR DESCRIPTION
Values outside of this range can lead to infinite animation (bad)