### PR TITLE
Fix double segment completions on interactive animations

### DIFF
--- a/Sources/Stagehand/AnimationInstance/InteractiveAnimationInstance.swift
+++ b/Sources/Stagehand/AnimationInstance/InteractiveAnimationInstance.swift
@@ -75,14 +75,14 @@ public final class InteractiveAnimationInstance {
         to relativeTimestamp: Double,
         using curve: AnimationCurve = LinearAnimationCurve(),
         duration: TimeInterval? = nil,
-        completion: ((_ finished: Bool) -> Void)? = nil
+        completion segmentCompletion: ((_ finished: Bool) -> Void)? = nil
     ) {
         guard !status.isComplete else {
             // The animation is already complete, there's nothing to animate here.
             return
         }
 
-        driver.animate(to: relativeTimestamp, using: curve, duration: duration, completion: completion)
+        driver.animate(to: relativeTimestamp, using: curve, duration: duration, segmentCompletion: segmentCompletion)
     }
 
     public func animateToBeginning(

--- a/Sources/Stagehand/Driver/InteractiveDriver.swift
+++ b/Sources/Stagehand/Driver/InteractiveDriver.swift
@@ -60,7 +60,7 @@ final class InteractiveDriver {
         to targetRelativeTimestamp: Double,
         using curve: AnimationCurve = LinearAnimationCurve(),
         duration: TimeInterval? = nil,
-        completion: ((_ finished: Bool) -> Void)? = nil
+        segmentCompletion: ((_ finished: Bool) -> Void)? = nil
     ) {
         guard !status.isComplete else {
             // The animation has already completed, so there's nothing to animate.
@@ -84,7 +84,7 @@ final class InteractiveDriver {
             segmentCurve: curve,
             startRelativeTimestamp: startRelativeTimestamp,
             endRelativeTimestamp: targetRelativeTimestamp,
-            completion: completion
+            completion: segmentCompletion
         )
 
         mode = .automatic(context)
@@ -247,10 +247,11 @@ final class InteractiveDriver {
         lastRenderedFrame = .init(relativeTimestamp: relativeTimestamp, executingInReverse: executingInReverse)
 
         if case let .automatic(context) = mode, context.endRelativeTimestamp == relativeTimestamp {
+            mode = .manual(relativeTimestamp: relativeTimestamp)
+
             // The automatic part of the animation is complete.
             context.displayLink.invalidate()
             context.completion?(true)
-            mode = .manual(relativeTimestamp: relativeTimestamp)
         }
     }
 }


### PR DESCRIPTION
We were causing the completion to get called twice for interactive animation automated segments, when calling `markAsComplete` during the segment completion (either explicitly, or now implicitly via the `completeOnFinish` parameter).

This fixes the issue by changing the mode to manual _before_ calling the segment completion.